### PR TITLE
ButtonState type with int() conversion

### DIFF
--- a/spacenavigator.py
+++ b/spacenavigator.py
@@ -45,6 +45,10 @@ def to_int16(y1,y2):
 # tuple for 6DOF results
 SpaceNavigator = namedtuple('SpaceNavigator', ['t','x', 'y', 'z', 'roll', 'pitch', 'yaw', 'buttons'])
 
+class ButtonState(list):
+    def __int__(self):
+        return sum((b << i) for (i, b) in enumerate(reversed(self)))
+
 class DeviceSpec(object):
     """Holds the specification of a single 3Dconnexion device"""
     def __init__(self, name, hid_id, led_id, mappings, button_mapping, axis_scale=350.0):
@@ -55,7 +59,7 @@ class DeviceSpec(object):
         self.button_mapping = button_mapping
         self.axis_scale = axis_scale        
         # initialise to a vector of 0s for each state
-        self.dict_state = {"buttons":[]}
+        self.dict_state = {"buttons":ButtonState()}
         self.tuple_state = SpaceNavigator(-1,0,0,0,0,0,0,[])
         # start in disconnected state
         self.device = None        


### PR DESCRIPTION
Add integer semantics to the `buttons` list. Allows writing an application which is compatible with both 0.1 and 0.2.

```python
def my_button_callback(state, buttons):
    print("buttons as list:", buttons)
    print("buttons as int (version 0.1 compatible):", int(buttons))
```


