### PR TITLE
Add support for the SpacePilot Pro

### DIFF
--- a/spacenavigator.py
+++ b/spacenavigator.py
@@ -373,6 +373,45 @@ device_specs = {
         ],  # FIT
         axis_scale=350.0,
     ),
+    "SpacePilot Pro": DeviceSpec(
+        name="SpacePilot Pro",
+        # vendor ID and product ID
+        hid_id=[0x46D, 0xC629],
+        # LED HID usage code pair
+        led_id=[0x8, 0x4B],
+        mappings={
+            "x": AxisSpec(channel=1, byte1=1, byte2=2, scale=1),
+            "y": AxisSpec(channel=1, byte1=3, byte2=4, scale=-1),
+            "z": AxisSpec(channel=1, byte1=5, byte2=6, scale=-1),
+            "pitch": AxisSpec(channel=2, byte1=1, byte2=2, scale=-1),
+            "roll": AxisSpec(channel=2, byte1=3, byte2=4, scale=-1),
+            "yaw": AxisSpec(channel=2, byte1=5, byte2=6, scale=1),
+        },
+        button_mapping=[
+            ButtonSpec(channel=3, byte=4, bit=0),  # SHIFT
+            ButtonSpec(channel=3, byte=3, bit=6),  # ESC
+            ButtonSpec(channel=3, byte=4, bit=1),  # CTRL
+            ButtonSpec(channel=3, byte=3, bit=7),  # ALT
+            ButtonSpec(channel=3, byte=3, bit=1),  # 1
+            ButtonSpec(channel=3, byte=3, bit=2),  # 2
+            ButtonSpec(channel=3, byte=2, bit=6),  # 3
+            ButtonSpec(channel=3, byte=2, bit=7),  # 4
+            ButtonSpec(channel=3, byte=3, bit=0),  # 5
+            ButtonSpec(channel=3, byte=1, bit=0),  # MENU
+            ButtonSpec(channel=3, byte=4, bit=6),  # -
+            ButtonSpec(channel=3, byte=4, bit=5),  # +
+            ButtonSpec(channel=3, byte=4, bit=4),  # DOMINANT
+            ButtonSpec(channel=3, byte=4, bit=3),  # PAN/ZOOM
+            ButtonSpec(channel=3, byte=4, bit=2),  # ROTATION
+            ButtonSpec(channel=3, byte=2, bit=0),  # ROLL CLOCKWISE
+            ButtonSpec(channel=3, byte=1, bit=2),  # TOP
+            ButtonSpec(channel=3, byte=1, bit=5),  # FRONT
+            ButtonSpec(channel=3, byte=1, bit=4),  # REAR
+            ButtonSpec(channel=3, byte=2, bit=2),  # ISO
+            ButtonSpec(channel=3, byte=1, bit=1),  # FIT
+        ], 
+        axis_scale=350.0,
+    ),
 }
 
 


### PR DESCRIPTION
I wasn't sure how to order the button mapping, as the buttons are laid out differently on the SpacePilot Pro compared to others. So I ordered them top to bottom, left and right.

I thought about putting the matching buttons at the same index as on the other devices, but that would lead to weird placement as well, because the "5" button would be separated from "1"-"4" then.